### PR TITLE
Check to see if current user can see all settings

### DIFF
--- a/src/Forms/class-adminform.php
+++ b/src/Forms/class-adminform.php
@@ -139,11 +139,9 @@ class AdminForm extends AdminBase {
 
 		$allow_edition = false;
 
-		$current_roles = wp_get_current_user()->roles;
-
 		$page_title = get_admin_page_title();
 
-		if ( array_intersect( [ 'administrator', 'editor' ], $current_roles ) ) {
+		if ( current_user_can('manage_options') ) {
 			$allow_edition = true;
 		}
 		?>


### PR DESCRIPTION
We should check access with current_user_can, the way we do it today can create problems for users being superadmins for example and WP discourages checking against roles, rather than checking for capabilities.

We had an example on a multisite where the superadmin got false for $allow_edition and thus couldn't access the plugin settings fully.

manage_otions will render it for admins and super admins (superadmins always get true on current_user_can)
If we want editors to have access as well, edit_pages would probably be a good capability. If we check against edit_pages we need to supply the function with a $object_id param.