### PR TITLE
Force full width

### DIFF
--- a/assets/css/custom-cookie-message-popup.css
+++ b/assets/css/custom-cookie-message-popup.css
@@ -6,6 +6,8 @@
 	will-change: transform;
 	z-index: 25000;
 	font-size: inherit;
+	left: 0;
+	right: 0;
 }
 
 .custom-cookie-message-banner__content {


### PR DESCRIPTION
If container element isn't full width the cookie banner won't fill screen.