### PR TITLE
bump version in src/class-main.php

### DIFF
--- a/src/class-main.php
+++ b/src/class-main.php
@@ -23,7 +23,7 @@ class Main {
 	 *
 	 * @var string
 	 */
-	protected $version = '2.4.7';
+	protected $version = '2.4.8';
 
 	/**
 	 * Store singlenton CustomCookieMessage\Main.


### PR DESCRIPTION
bumps version to 2.4.8 in src/class-main.php 
Without it, any cached version of the javascript from 2.4.7 would still be requested.